### PR TITLE
[17.0][IMP] voip_oca: add summary to activity list

### DIFF
--- a/voip_oca/static/src/components/activity_list/activity_list.xml
+++ b/voip_oca/static/src/components/activity_list/activity_list.xml
@@ -9,7 +9,12 @@
                 t-on-click="() => this.onClick(activity)"
             >
                 <span class="fw-bold" t-esc="activity.main_partner_id[1]" />
-                <span class="fst-italic" t-esc="activity.res_name" />
+                <t t-if="activity.main_partner_id[1] != activity.res_name">
+                    <span class="fst-normal" t-esc="activity.res_name" />
+                </t>
+                <t t-if="activity.summary">
+                    <span class="fst-italic" t-esc="activity.summary" />
+                </t>
             </div>
         </t>
 


### PR DESCRIPTION
Hi @etobella, I'd like to propose the following changes:

- Add activity summary to the activity list to provide a more detailed preview.

- Also hides the `res_name` if it belongs to the same partner and doesn't originate from another model.

The result looks like this:

![2025-03-14_09-34](https://github.com/user-attachments/assets/a271c232-e658-4e7b-a0ff-b16464412219)
